### PR TITLE
making ADDON_SOURCES absolute paths, to fix compiling errors when using Makefile

### DIFF
--- a/addon_config.mk
+++ b/addon_config.mk
@@ -51,8 +51,8 @@ common:
 	# in the src folders in libs and the root of the addon. if your addon needs
 	# to include files in different places or a different set of files per platform
 	# they can be specified here
-	ADDON_SOURCES = src/ofxLearn.cpp
-	ADDON_SOURCES += src/ofxLearn.h
+	ADDON_SOURCES = $(OF_ROOT)/addons/ofxLearn/src/ofxLearn.cpp
+	ADDON_SOURCES += $(OF_ROOT)/addons/ofxLearn/src/ofxLearn.h
 	
 	# some addons need resources to be copied to the bin/data folder of the project
 	# specify here any files that need to be copied, you can use wildcards like * and ?


### PR DESCRIPTION
Hi @genekogan,

For those who like to build the app using just the Makefile, the current build doesn't compile.  The `addon_config.mk` sets the `ADDON_SOURCES`, but the `$(OF_ROOT)/libs/openFrameworksCompiled/project/makefileCommon/compile.project.mk` is unable to resolve them.
By commenting out those lines the project starts compiling well, but struggles and fail after when attempts to compile `libs/dlib` sources.
I was surprised that using XCode, the examples compiled well, but not using `make`.  So, I went back to this file and making the paths absolute, it excludes everything but the `ofxLearn.h` and `ofxLearn.cpp`, and was able to compile the examples.

This is related to https://github.com/genekogan/ofxLearn/issues/2.

Hope this helps.  Amazing project, by the way.

Best,